### PR TITLE
Add owning user to pull_request_count labels

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -21,7 +21,7 @@ func AddMetrics() map[string]*prometheus.Desc {
 	APIMetrics["PullRequestCount"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "pull_request_count"),
 		"Total number of pull requests for given repository",
-		[]string{"repo"}, nil,
+		[]string{"repo", "user"}, nil,
 	)
 	APIMetrics["Watchers"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "watchers"),
@@ -85,7 +85,7 @@ func (e *Exporter) processMetrics(data []*Datum, rates *RateLimits, ch chan<- pr
 		ch <- prometheus.MustNewConstMetric(e.APIMetrics["OpenIssues"], prometheus.GaugeValue, (x.OpenIssues - float64(prCount)), x.Name, x.Owner.Login, strconv.FormatBool(x.Private), strconv.FormatBool(x.Fork), strconv.FormatBool(x.Archived), x.License.Key, x.Language)
 
 		// prCount
-		ch <- prometheus.MustNewConstMetric(e.APIMetrics["PullRequestCount"], prometheus.GaugeValue, float64(prCount), x.Name)
+		ch <- prometheus.MustNewConstMetric(e.APIMetrics["PullRequestCount"], prometheus.GaugeValue, float64(prCount), x.Name, x.Owner.Login)
 	}
 
 	// Set Rate limit stats


### PR DESCRIPTION
Resolves #30

I have noticed, that if multiple users (or orgs) share a repository with the same name, then the `pull_request_count` metrics will cause an error while collecting metrics because the same metric has already been collected. In most cases this is because one user has forked the repo of another user.

I have fixed this by adding the owning users name to the labels of the metric. While this solves the problem, it only makes a bit of sense since the number of pull requests of both repositories will always be the same. causing small amounts of duplicate data to be reported.