### PR TITLE
Fix loop that never returns on http error

### DIFF
--- a/exporter/http.go
+++ b/exporter/http.go
@@ -40,7 +40,7 @@ func asyncHTTPGets(targets []string, token string) ([]*Response, error) {
 		case r := <-ch:
 			if r.err != nil {
 				log.Errorf("Error scraping API, Error: %v", r.err)
-				break
+				return nil, r.err
 			}
 			responses = append(responses, r)
 


### PR DESCRIPTION
  - While running this exporter in the [grafana agent](https://github.com/grafana/agent), we have identified a loop that never returns in case of http error. This in turn causes the agent to never release a lock, preventing it from making progress.
  - Note: I have not added additional metrics to report errors as I am trying to keep the scope of this change minimal, but it would be a good idea to add a gauge as stated in the [prometheus guidelines](https://prometheus.io/docs/instrumenting/writing_exporters/#failed-scrapes).
  - See https://github.com/grafana/agent/issues/3144