### PR TITLE
Rename module name and imports

### DIFF
--- a/exporter/structs.go
+++ b/exporter/structs.go
@@ -3,7 +3,7 @@ package exporter
 import (
 	"net/http"
 
-	"github.com/infinityworks/github-exporter/config"
+	"github.com/githubexporter/github-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/infinityworks/github-exporter
+module github.com/githubexporter/github-exporter
 
 go 1.19
 

--- a/http/server.go
+++ b/http/server.go
@@ -1,11 +1,12 @@
 package http
 
 import (
-	"github.com/infinityworks/github-exporter/exporter"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
+
+	"github.com/githubexporter/github-exporter/exporter"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Server struct {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	conf "github.com/infinityworks/github-exporter/config"
-	"github.com/infinityworks/github-exporter/exporter"
-	"github.com/infinityworks/github-exporter/http"
+	conf "github.com/githubexporter/github-exporter/config"
+	"github.com/githubexporter/github-exporter/exporter"
+	"github.com/githubexporter/github-exporter/http"
 	"github.com/infinityworks/go-common/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -2,16 +2,17 @@ package test
 
 import (
 	"fmt"
-	"github.com/infinityworks/github-exporter/config"
-	"github.com/infinityworks/github-exporter/exporter"
-	web "github.com/infinityworks/github-exporter/http"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/steinfletcher/apitest"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/githubexporter/github-exporter/config"
+	"github.com/githubexporter/github-exporter/exporter"
+	web "github.com/githubexporter/github-exporter/http"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/steinfletcher/apitest"
 )
 
 func TestHomepage(t *testing.T) {


### PR DESCRIPTION
I tried to import the exporter using the new organization but I got this error:

```
        github.com/githubexporter/github-exporter/config: github.com/githubexporter/github-exporter@v0.0.0-20230823145513-2de8370ecdf1: parsing go.mod:
        module declares its path as: github.com/infinityworks/github-exporter
                but was required as: github.com/githubexporter/github-exporter
```

I suspect is because the module name was not renamed. This PR changes it.