### PR TITLE
chore: replace deprecated `io/ioutil` functions with modern equivalences.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"net/url"
 	"path"
 	"strings"
@@ -118,7 +117,7 @@ func (c *Config) SetAPIToken(token string) {
 
 // SetAPITokenFromFile accepts a file containing an oauth2 token for usage in http.request
 func (c *Config) SetAPITokenFromFile(tokenFile string) error {
-	b, err := ioutil.ReadFile(tokenFile)
+	b, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return err
 	}

--- a/exporter/http.go
+++ b/exporter/http.go
@@ -2,7 +2,7 @@ package exporter
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -111,7 +111,7 @@ func getResponse(url string, token string, ch chan<- *Response) error {
 	defer resp.Body.Close()
 
 	// Read the body to a byte array so it can be used elsewhere
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("Error converting body to byte array: %v", err)
 	}

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -145,7 +145,7 @@ func githubPullsError() *apitest.Mock {
 }
 
 func readFile(path string) string {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
@@ -154,7 +154,7 @@ func readFile(path string) string {
 
 func bodyContains(substr string) func(*http.Response, *http.Request) error {
 	return func(res *http.Response, req *http.Request) error {
-		bytes, err := ioutil.ReadAll(res.Body)
+		bytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
As in Go 1.19, `io/ioutil` functions are marked as deprecated. This PR helps refactoring them and replace with modern equivalents, as suggested by Go's official docs