### PR TITLE
feat(exporter): include Git tag as attribute for `github_repo_release_downloads` metrics

### DIFF
--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -44,7 +44,7 @@ func AddMetrics() map[string]*prometheus.Desc {
 	APIMetrics["ReleaseDownloads"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "release_downloads"),
 		"Download count for a given release",
-		[]string{"repo", "user", "release", "name", "created_at"}, nil,
+		[]string{"repo", "user", "release", "name", "tag", "created_at"}, nil,
 	)
 	APIMetrics["Limit"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "rate", "limit"),
@@ -77,7 +77,7 @@ func (e *Exporter) processMetrics(data []*Datum, rates *RateLimits, ch chan<- pr
 
 		for _, release := range x.Releases {
 			for _, asset := range release.Assets {
-				ch <- prometheus.MustNewConstMetric(e.APIMetrics["ReleaseDownloads"], prometheus.GaugeValue, float64(asset.Downloads), x.Name, x.Owner.Login, release.Name, asset.Name, asset.CreatedAt)
+				ch <- prometheus.MustNewConstMetric(e.APIMetrics["ReleaseDownloads"], prometheus.GaugeValue, float64(asset.Downloads), x.Name, x.Owner.Login, release.Name, asset.Name, release.Tag, asset.CreatedAt)
 			}
 		}
 		prCount := 0

--- a/exporter/structs.go
+++ b/exporter/structs.go
@@ -44,6 +44,7 @@ type Datum struct {
 type Release struct {
 	Name   string  `json:"name"`
 	Assets []Asset `json:"assets"`
+	Tag    string  `json:"tag_name"`
 }
 
 type Pull struct {

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -47,10 +47,10 @@ func TestGithubExporter(t *testing.T) {
 		Assert(bodyContains(`github_repo_size_kb{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 946`)).
 		Assert(bodyContains(`github_repo_stars{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 120`)).
 		Assert(bodyContains(`github_repo_watchers{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 5`)).
-		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-02-28T08:25:53Z",name="myRepo_1.3.0_checksums.txt",release="1.3.0",repo="myRepo",user="myOrg"} 7292`)).
-		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-02-28T08:25:53Z",name="myRepo_1.3.0_windows_amd64.tar.gz",release="1.3.0",repo="myRepo",user="myOrg"} 21`)).
-		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-05-02T15:22:16Z",name="myRepo_2.0.0_checksums.txt",release="2.0.0",repo="myRepo",user="myOrg"} 14564`)).
-		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-05-02T15:22:16Z",name="myRepo_2.0.0_windows_amd64.tar.gz",release="2.0.0",repo="myRepo",user="myOrg"} 55`)).
+		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-02-28T08:25:53Z",name="myRepo_1.3.0_checksums.txt",release="1.3.0",repo="myRepo",tag="1.3.0",user="myOrg"} 7292`)).
+		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-02-28T08:25:53Z",name="myRepo_1.3.0_windows_amd64.tar.gz",release="1.3.0",repo="myRepo",tag="1.3.0",user="myOrg"} 21`)).
+		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-05-02T15:22:16Z",name="myRepo_2.0.0_checksums.txt",release="2.0.0",repo="myRepo",tag="2.0.0",user="myOrg"} 14564`)).
+		Assert(bodyContains(`github_repo_release_downloads{created_at="2019-05-02T15:22:16Z",name="myRepo_2.0.0_windows_amd64.tar.gz",release="2.0.0",repo="myRepo",tag="2.0.0",user="myOrg"} 55`)).
 		Status(http.StatusOK).
 		End()
 }


### PR DESCRIPTION
The `github_repo_release_downloads` metric only has the `release` attribute, which could be sometimes a human-readable name. This PR includes the Git tag value as metric's attribute, which is *usually* semver'ed

Potentially fixes https://github.com/grafana/agent/issues/6495