### PR TITLE
Restore archived label to github_repo_pull_request_count metric

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -32,7 +32,7 @@ github_repo_forks{archived="false",fork="false",language="Go",license="mit",priv
 github_repo_open_issues{archived="false",fork="false",language="Go",license="mit",private="false",repo="github-exporter",user="githubexporter"} 28
 # HELP github_repo_pull_request_count Total number of pull requests for given repository
 # TYPE github_repo_pull_request_count gauge
-github_repo_pull_request_count{repo="github-exporter",user="githubexporter"} 7
+github_repo_pull_request_count{archived="false",fork="false",language="Go",license="mit",private="false",repo="github-exporter",user="githubexporter"} 7
 # HELP github_repo_size_kb Size in KB for given repository
 # TYPE github_repo_size_kb gauge
 github_repo_size_kb{archived="false",fork="false",language="Go",license="mit",private="false",repo="github-exporter",user="githubexporter"} 2185

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -40,7 +40,7 @@ func AddMetrics(cfg *config.Config) map[string]*prometheus.Desc {
 	APIMetrics["PullRequestCount"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "pull_request_count"),
 		"Total number of pull requests for given repository",
-		[]string{"repo", "user"}, nil,
+		[]string{"repo", "user", "private", "fork", "archived", "license", "language"}, nil,
 	)
 	APIMetrics["Watchers"] = prometheus.NewDesc(
 		prometheus.BuildFQName("github", "repo", "watchers"),
@@ -115,7 +115,7 @@ func (e *Exporter) processMetrics(data []*Datum, rates *[]RateLimit, ch chan<- p
 		ch <- prometheus.MustNewConstMetric(e.APIMetrics["OpenIssues"], prometheus.GaugeValue, float64(x.OpenIssues-prCount), x.Name, x.Owner.Login, strconv.FormatBool(x.Private), strconv.FormatBool(x.Fork), strconv.FormatBool(x.Archived), x.License.Key, x.Language)
 
 		// prCount
-		ch <- prometheus.MustNewConstMetric(e.APIMetrics["PullRequestCount"], prometheus.GaugeValue, float64(prCount), x.Name, x.Owner.Login)
+		ch <- prometheus.MustNewConstMetric(e.APIMetrics["PullRequestCount"], prometheus.GaugeValue, float64(prCount), x.Name, x.Owner.Login, strconv.FormatBool(x.Private), strconv.FormatBool(x.Fork), strconv.FormatBool(x.Archived), x.License.Key, x.Language)
 	}
 
 	// Set Rate limit stats

--- a/test/github_exporter_test.go
+++ b/test/github_exporter_test.go
@@ -56,7 +56,7 @@ func TestGithubExporter(t *testing.T) {
 		Assert(bodyContains(`github_rate_reset{resource="integration_manifest"} 3e+09`)).
 		Assert(bodyContains(`github_rate_reset{resource="search"} 3e+09`)).
 		Assert(bodyContains(`github_repo_forks{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 10`)).
-		Assert(bodyContains(`github_repo_pull_request_count{repo="myRepo",user="myOrg"} 3`)).
+		Assert(bodyContains(`github_repo_pull_request_count{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 3`)).
 		Assert(bodyContains(`github_repo_open_issues{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 2`)).
 		Assert(bodyContains(`github_repo_size_kb{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 946`)).
 		Assert(bodyContains(`github_repo_stars{archived="false",fork="false",language="Go",license="mit",private="false",repo="myRepo",user="myOrg"} 120`)).


### PR DESCRIPTION
## Summary

This PR restores the `archived` label to the `github_repo_pull_request_count` metric, making it consistent with other repository metrics like `github_repo_open_issues`.

## Example Output

Before:
```
github_repo_pull_request_count{repo="github-exporter",user="githubexporter"} 7
```

After:
```
github_repo_pull_request_count{archived="false",fork="false",language="Go",license="mit",private="false",repo="github-exporter",user="githubexporter"} 7
```